### PR TITLE
pass game input from workflow via action.yml to validate.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ runs:
   using: "composite"
   steps:
     - name: Validate Mod
-      run: ${{ inputs.action-directory }}/validate.sh ${{ inputs.mod-directory }} ${{ inputs.action-directory }}
+      run: ${{ inputs.action-directory }}/validate.sh ${{ inputs.mod-directory }} ${{ inputs.action-directory }} ${{ inputs.game }}
       shell: sh


### PR DESCRIPTION
When i copied your example from the ReadMe and ran it i got: `validation/validate.sh: Permission denied`

I found that the error was that the game 
```yml
      - name: Validate
        uses: ./validation/
        with:
          mod-directory: 'mod'
          action-directory: 'validation'
          game: 'vic3' # Also supports ck3
```
was not being passed in the action.yml to the validate.sh script